### PR TITLE
Fix void_nigga_fixed lua script error

### DIFF
--- a/void.lua
+++ b/void.lua
@@ -152,12 +152,12 @@ end
 
 entity.get_animlayer = function(idx, layer_idx)
     local addr = entity.get_address(idx)
-    if not addr ) then
+    if not addr then
         print("[VOID] Warning: Failed to get entity address for player ", idx)
         return nil
     end
     local layer_ptr = ffi.cast("C_AnimationLayer *", ffi.cast('uintptr_t', addr) + 0x2990)[0]
-    if layer_ptr )
+    if layer_ptr then
         return layer_ptr[layer_idx]
     end
     return nil


### PR DESCRIPTION
Fix Lua syntax errors in `void.lua` where `then` was expected near `)`.

---
<a href="https://cursor.com/background-agent?bcId=bc-91c841f5-88f9-4911-9274-aed14d45b6f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-91c841f5-88f9-4911-9274-aed14d45b6f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

