### PR TITLE
Fix lua syntax error

### DIFF
--- a/VOID.lua
+++ b/VOID.lua
@@ -1534,12 +1534,12 @@ function ctx:setup_visuals()
             
             for _, player in ipairs(players) do
                 if not entity.is_alive(player) then
-                    continue
+                    goto continue
                 end
                 
                 local x, y, w, h = entity.get_bounding_box(player)
                 if not x then
-                    continue
+                    goto continue
                 end
                 
                 local color = self.ui.menu.visuals.color()
@@ -1559,6 +1559,7 @@ function ctx:setup_visuals()
                     local health_color = health > 50 and {255, 255, 0, 255} or {255, 0, 0, 255}
                     renderer.text(x - 5, y, health_color[1], health_color[2], health_color[3], health_color[4], 'r', 0, tostring(health))
                 end
+                ::continue::
             end
         end
     }


### PR DESCRIPTION
Replace `continue` statements with `goto` labels to resolve a Lua syntax error.

The original code used `continue` statements, which are not supported in Lua. This caused a syntax error like "'=' expected near 'end'". The fix involves using `goto continue` and a `::continue::` label at the end of the loop to achieve the desired iteration skipping behavior in a Lua-compatible way.

---
<a href="https://cursor.com/background-agent?bcId=bc-3bdae8cb-3689-4aa4-91bd-e6a950520b82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3bdae8cb-3689-4aa4-91bd-e6a950520b82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

